### PR TITLE
chore: Update Lyralis link and description

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ I am a university student majoring in computer science, with a particular intere
 
 ## Affiliations
 
-- [Lyralis](https://github.com/lyralis), A creative club centered around engineers.
+- [Lyralis](https://lyralis.org), An underground creative collective where engineers gather to build the future.
 
 ## Interests
 


### PR DESCRIPTION
Update the Lyralis affiliation link to the official website (lyralis.org) and revise the description to better reflect its nature as an underground creative collective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)