### PR TITLE
chore: update actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,21 +19,21 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup Development Environment
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Build with Zola
         run: zola build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./build
   deploy:
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deploy-to-pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup Development Environment
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
 
       - name: Build with Zola
         run: zola build


### PR DESCRIPTION
## Summary

The Deploy workflow emits Node.js 20 deprecation warnings (`actions/configure-pages@v4`, `actions/upload-artifact@v4` via `upload-pages-artifact@v3`, `jdx/mise-action@v2`). GitHub forces Node.js 24 starting **June 16, 2026** and removes Node.js 20 from runners on September 16, 2026.

Bump all actions in both workflows to their latest major versions:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 (CI) / v5 (CD) | v6 |
| jdx/mise-action | v3 (CI) / v2 (CD) | v4 |
| actions/configure-pages | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

All bumps are Node.js runtime updates with no configuration changes required (verified mise-action v4 release notes; Pages actions keep the same inputs).

## Verification

- [ ] CI build passes on this PR
- [ ] Deploy workflow succeeds after merge without deprecation warnings

Generated with Claude Code